### PR TITLE
Fix #24: Fix invalid CORS headers and add optional preflight request handling to `CorsAllowAllMiddleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.2.1 under development
 
-- no changes in this release.
+- Bug #24: Fix invalid CORS headers and add optional preflight request handling to `CorsAllowAllMiddleware` (@samdark)
 
 ## 1.2.0 March 10, 2026
 

--- a/docs/guide/en/cors-allow-all-middleware.md
+++ b/docs/guide/en/cors-allow-all-middleware.md
@@ -25,4 +25,15 @@ use Yiisoft\HttpMiddleware\CorsAllowAllMiddleware;
 $middleware = new CorsAllowAllMiddleware();
 ```
 
-There are no constructor arguments, the middleware is ready to use out of the box.
+To handle CORS preflight requests without passing them to the request handler, provide a PSR-17 response factory:
+
+```php
+use Psr\Http\Message\ResponseFactoryInterface;
+use Yiisoft\HttpMiddleware\CorsAllowAllMiddleware;
+
+/** @var ResponseFactoryInterface $responseFactory */
+$middleware = new CorsAllowAllMiddleware($responseFactory);
+```
+
+The constructor argument is optional for backward compatibility. Without a response factory, preflight requests are
+passed to the next request handler and CORS headers are added to its response.

--- a/src/CorsAllowAllMiddleware.php
+++ b/src/CorsAllowAllMiddleware.php
@@ -10,6 +10,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+use function count;
+use function in_array;
+
 /**
  * Adds Cross-Origin Resource Sharing (CORS) headers allowing everything to the response.
  *
@@ -30,9 +33,10 @@ final class CorsAllowAllMiddleware implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $origin = $request->getHeaderLine('Origin');
+        $origins = $request->getHeader('Origin');
+        $origin = count($origins) === 1 ? $origins[0] : '';
         $isPreflight = $request->getMethod() === 'OPTIONS'
-            && $request->hasHeader('Access-Control-Request-Method');
+            && $request->getHeaderLine('Access-Control-Request-Method') !== '';
 
         $response = $isPreflight && $this->responseFactory !== null
             ? $this->responseFactory->createResponse(204)
@@ -47,8 +51,12 @@ final class CorsAllowAllMiddleware implements MiddlewareInterface
             }
         }
 
+        $vary = array_map(trim(...), explode(',', strtolower($response->getHeaderLine('Vary'))));
+        if (!in_array('origin', $vary, true)) {
+            $response = $response->withAddedHeader('Vary', 'Origin');
+        }
+
         $response = $response
-            ->withHeader('Vary', 'Origin')
             ->withHeader('Access-Control-Allow-Origin', $origin === '' ? '*' : $origin)
             ->withHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,HEAD,POST,PUT,PATCH,DELETE')
             ->withHeader('Access-Control-Max-Age', '86400');

--- a/src/CorsAllowAllMiddleware.php
+++ b/src/CorsAllowAllMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\HttpMiddleware;
 
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -20,18 +21,52 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final class CorsAllowAllMiddleware implements MiddlewareInterface
 {
+    /**
+     * @param ResponseFactoryInterface|null $responseFactory Factory used to short-circuit preflight requests.
+     */
+    public function __construct(
+        private readonly ?ResponseFactoryInterface $responseFactory = null,
+    ) {}
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $response = $handler->handle($request);
+        $origin = $request->getHeaderLine('Origin');
+        $isPreflight = $request->getMethod() === 'OPTIONS'
+            && $request->hasHeader('Access-Control-Request-Method');
 
-        return $response
-            ->withHeader('Allow', '*')
+        $response = $isPreflight && $this->responseFactory !== null
+            ? $this->responseFactory->createResponse(204)
+            : $handler->handle($request);
+
+        $exposedHeaders = [];
+        /** @var array<string, string[]> $headers */
+        $headers = $response->getHeaders();
+        foreach ($headers as $name => $_) {
+            if (strtolower($name) !== 'set-cookie') {
+                $exposedHeaders[] = $name;
+            }
+        }
+
+        $response = $response
             ->withHeader('Vary', 'Origin')
-            ->withHeader('Access-Control-Allow-Origin', '*')
+            ->withHeader('Access-Control-Allow-Origin', $origin === '' ? '*' : $origin)
             ->withHeader('Access-Control-Allow-Methods', 'GET,OPTIONS,HEAD,POST,PUT,PATCH,DELETE')
-            ->withHeader('Access-Control-Allow-Headers', '*')
-            ->withHeader('Access-Control-Expose-Headers', '*')
-            ->withHeader('Access-Control-Allow-Credentials', 'true')
             ->withHeader('Access-Control-Max-Age', '86400');
+
+        if ($origin === '') {
+            return $response
+                ->withHeader('Access-Control-Allow-Headers', '*')
+                ->withHeader('Access-Control-Expose-Headers', '*');
+        }
+
+        $requestedHeaders = $request->getHeaderLine('Access-Control-Request-Headers');
+        if ($requestedHeaders !== '') {
+            $response = $response->withHeader('Access-Control-Allow-Headers', $requestedHeaders);
+        }
+        if ($exposedHeaders !== []) {
+            $response = $response->withHeader('Access-Control-Expose-Headers', implode(',', $exposedHeaders));
+        }
+
+        return $response->withHeader('Access-Control-Allow-Credentials', 'true');
     }
 }

--- a/tests/CorsAllowAllMiddlewareTest.php
+++ b/tests/CorsAllowAllMiddlewareTest.php
@@ -45,14 +45,39 @@ final class CorsAllowAllMiddlewareTest extends TestCase
         $requestHandler = new FakeRequestHandler(
             (new Response())
                 ->withHeader('X-Request-Id', '42')
-                ->withHeader('Set-Cookie', 'token=secret'),
+                ->withHeader('Set-Cookie', 'token=secret')
+                ->withHeader('Vary', 'Accept-Encoding'),
         );
 
         $response = (new CorsAllowAllMiddleware())->process($request, $requestHandler);
 
         assertSame('https://example.com', $response->getHeaderLine('Access-Control-Allow-Origin'));
         assertSame('true', $response->getHeaderLine('Access-Control-Allow-Credentials'));
-        assertSame('X-Request-Id', $response->getHeaderLine('Access-Control-Expose-Headers'));
+        assertSame('X-Request-Id,Vary', $response->getHeaderLine('Access-Control-Expose-Headers'));
+        assertSame(['Accept-Encoding', 'Origin'], $response->getHeader('Vary'));
+    }
+
+    public function testMultipleOriginsAreNotReflected(): void
+    {
+        $request = (new ServerRequest())
+            ->withHeader('Origin', ['https://example.com', 'https://example.org']);
+
+        $response = (new CorsAllowAllMiddleware())->process($request, new FakeRequestHandler());
+
+        assertSame('*', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        assertSame('', $response->getHeaderLine('Access-Control-Allow-Credentials'));
+    }
+
+    public function testExistingOriginInVaryIsNotDuplicated(): void
+    {
+        $handlerResponse = (new Response())->withHeader('Vary', 'Accept-Encoding, ORIGIN');
+
+        $response = (new CorsAllowAllMiddleware())->process(
+            new ServerRequest(),
+            new FakeRequestHandler($handlerResponse),
+        );
+
+        assertSame(['Accept-Encoding, ORIGIN'], $response->getHeader('Vary'));
     }
 
     public function testRequestWithFactoryIsHandled(): void
@@ -73,6 +98,31 @@ final class CorsAllowAllMiddlewareTest extends TestCase
         (new CorsAllowAllMiddleware(new ResponseFactory()))->process($request, $requestHandler);
 
         assertSame($request, $requestHandler->getLastRequest());
+    }
+
+    public function testOptionsWithEmptyRequestedMethodIsHandled(): void
+    {
+        $request = (new ServerRequest())
+            ->withMethod('OPTIONS')
+            ->withHeader('Access-Control-Request-Method', '');
+        $requestHandler = new FakeRequestHandler();
+
+        (new CorsAllowAllMiddleware(new ResponseFactory()))->process($request, $requestHandler);
+
+        assertSame($request, $requestHandler->getLastRequest());
+    }
+
+    public function testPreflightWithoutFactoryIsHandled(): void
+    {
+        $request = (new ServerRequest())
+            ->withMethod('OPTIONS')
+            ->withHeader('Access-Control-Request-Method', 'POST');
+        $requestHandler = new FakeRequestHandler(new Response(202));
+
+        $response = (new CorsAllowAllMiddleware())->process($request, $requestHandler);
+
+        assertSame($request, $requestHandler->getLastRequest());
+        assertSame(202, $response->getStatusCode());
     }
 
     public function testPreflight(): void

--- a/tests/CorsAllowAllMiddlewareTest.php
+++ b/tests/CorsAllowAllMiddlewareTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Yiisoft\HttpMiddleware\Tests;
 
 use HttpSoft\Message\Response;
+use HttpSoft\Message\ResponseFactory;
 use HttpSoft\Message\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\HttpMiddleware\CorsAllowAllMiddleware;
 use Yiisoft\HttpMiddleware\Tests\Support\FakeRequestHandler;
 
+use function PHPUnit\Framework\assertNull;
 use function PHPUnit\Framework\assertSame;
 
 final class CorsAllowAllMiddlewareTest extends TestCase
@@ -25,16 +27,69 @@ final class CorsAllowAllMiddlewareTest extends TestCase
         assertSame($request, $requestHandler->getLastRequest());
         assertSame(
             [
-                'Allow' => ['*'],
                 'Vary' => ['Origin'],
                 'Access-Control-Allow-Origin' => ['*'],
                 'Access-Control-Allow-Methods' => ['GET,OPTIONS,HEAD,POST,PUT,PATCH,DELETE'],
+                'Access-Control-Max-Age' => ['86400'],
                 'Access-Control-Allow-Headers' => ['*'],
                 'Access-Control-Expose-Headers' => ['*'],
-                'Access-Control-Allow-Credentials' => ['true'],
-                'Access-Control-Max-Age' => ['86400'],
             ],
             $response->getHeaders(),
         );
+    }
+
+    public function testCredentialedRequest(): void
+    {
+        $request = (new ServerRequest())
+            ->withHeader('Origin', 'https://example.com');
+        $requestHandler = new FakeRequestHandler(
+            (new Response())
+                ->withHeader('X-Request-Id', '42')
+                ->withHeader('Set-Cookie', 'token=secret'),
+        );
+
+        $response = (new CorsAllowAllMiddleware())->process($request, $requestHandler);
+
+        assertSame('https://example.com', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        assertSame('true', $response->getHeaderLine('Access-Control-Allow-Credentials'));
+        assertSame('X-Request-Id', $response->getHeaderLine('Access-Control-Expose-Headers'));
+    }
+
+    public function testRequestWithFactoryIsHandled(): void
+    {
+        $request = new ServerRequest();
+        $requestHandler = new FakeRequestHandler();
+
+        (new CorsAllowAllMiddleware(new ResponseFactory()))->process($request, $requestHandler);
+
+        assertSame($request, $requestHandler->getLastRequest());
+    }
+
+    public function testOptionsWithoutRequestedMethodIsHandled(): void
+    {
+        $request = (new ServerRequest())->withMethod('OPTIONS');
+        $requestHandler = new FakeRequestHandler();
+
+        (new CorsAllowAllMiddleware(new ResponseFactory()))->process($request, $requestHandler);
+
+        assertSame($request, $requestHandler->getLastRequest());
+    }
+
+    public function testPreflight(): void
+    {
+        $request = (new ServerRequest())
+            ->withMethod('OPTIONS')
+            ->withHeader('Origin', 'https://example.com')
+            ->withHeader('Access-Control-Request-Method', 'POST')
+            ->withHeader('Access-Control-Request-Headers', 'Content-Type, Authorization');
+        $requestHandler = new FakeRequestHandler();
+
+        $response = (new CorsAllowAllMiddleware(new ResponseFactory()))->process($request, $requestHandler);
+
+        assertNull($requestHandler->getLastRequest());
+        assertSame(204, $response->getStatusCode());
+        assertSame('https://example.com', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        assertSame('Content-Type, Authorization', $response->getHeaderLine('Access-Control-Allow-Headers'));
+        assertSame('true', $response->getHeaderLine('Access-Control-Allow-Credentials'));
     }
 }


### PR DESCRIPTION
Fixes #24.

- reflect the request origin when credentials are enabled instead of combining credentials with wildcard values
- echo requested preflight headers and explicitly expose downstream response headers
- remove the unrelated Allow header
- optionally short-circuit valid preflight requests with a PSR-17 response factory while keeping the zero-argument constructor backward compatible
- document the optional response factory and cover both compatibility paths

Checks:
- PHPUnit: 111 tests, 206 assertions
- Psalm
- PHP CS Fixer
- Rector
- Infection: 100% covered MSI for CorsAllowAllMiddleware